### PR TITLE
Fix desktop extent with monitors in negative space

### DIFF
--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -144,7 +144,8 @@ impl WlxClient {
             extent.0 = extent.0.max(output.logical_pos.0 + output.logical_size.0);
             extent.1 = extent.1.max(output.logical_pos.1 + output.logical_size.1);
         }
-        extent
+        let origin = self.get_desktop_origin();
+        (extent.0 - origin.0, extent.1 - origin.1)
     }
 
     pub fn iter_events(&mut self) -> impl Iterator<Item = OutputChangeEvent> + '_ {


### PR DESCRIPTION
When monitors are in negative space wlx-overlay-s pointer movement breaks because the extent calculation assumes that monitors originate from 0x0.