### PR TITLE
Add NvFBC support on X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvfbc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b339b5c554c55904a032ec03598191071b8fbead3b89a8aabc2465727803ecc2"
+dependencies = [
+ "nvfbc-sys",
+]
+
+[[package]]
+name = "nvfbc-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1312c329848acc8f07a288dac9ba67edddae2c222a018916c01e47dad1f14d5b"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1768,8 @@ dependencies = [
  "idmap",
  "libc",
  "log",
+ "nvfbc",
+ "once_cell",
  "pipewire",
  "rxscreen",
  "smithay-client-toolkit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,21 @@ wayland = [
   "dep:wayland-protocols",
 ]
 xshm = ["dep:rxscreen"]
+nvfbc = ["dep:nvfbc"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+libc = "0.2.171"
 ashpd = { version = "0.11.0", default_features = false, features = [
   "async-std",
 ], optional = true }
 drm-fourcc = "2.2.0"
 idmap = "0.2.21"
-libc = "0.2.171"
 log = "0.4.27"
+nvfbc = { version = "0.1.5", optional = true }
+once_cell = "1.19.0"
 pipewire = { git = "https://gitlab.freedesktop.org/galister/pipewire-rs.git", ref = "ba32202c3c391004c3bb533b58fa75a50e47ff57", features = [
   "v0_3_33",
 ], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,10 @@ pub mod wlr_screencopy;
 #[cfg(feature = "pipewire")]
 pub mod pipewire;
 
+#[cfg(feature = "nvfbc")]
+pub mod nvfbc;
 #[cfg(feature = "xshm")]
 pub mod xshm;
-
 pub trait WlxCapture<U, R> {
     fn init(
         &mut self,

--- a/src/nvfbc.rs
+++ b/src/nvfbc.rs
@@ -40,7 +40,9 @@ impl WlxCapture for NVFBCCapture {
                     let monitor_name = "NvFBC Main Monitor"; //capturer.status().unwrap().outputs[0].name;
                     match rx_cmd.recv() {
                         Ok(_) => {
-                            if let Ok(frame_info) = capturer.next_frame(CaptureMethod::NoWait) {
+                            if let Ok(frame_info) =
+                                capturer.next_frame(CaptureMethod::NoWaitIfNewFrame)
+                            {
                                 log::trace!("{:#?}", frame_info);
 
                                 let memptr_frame = MemPtrFrame {
@@ -72,7 +74,7 @@ impl WlxCapture for NVFBCCapture {
                                     }
                                 }
                             } else {
-                                log::debug!("{}: NvFBC capture failed failed", monitor_name);
+                                log::debug!("{}: NvFBC capture failed", monitor_name);
                             }
                         }
                         Err(_) => {

--- a/src/nvfbc.rs
+++ b/src/nvfbc.rs
@@ -1,0 +1,76 @@
+use crate::{
+    frame::{DrmFormat, FrameFormat, MemPtrFrame, WlxFrame, DRM_FORMAT_ARGB8888},
+    WlxCapture,
+};
+use nvfbc::system::CaptureMethod;
+use nvfbc::{BufferFormat, SystemCapturer};
+pub struct NVFBCCapture {
+    capturer: SystemCapturer,
+    fps: u32,
+    // frame: Option<Box<[u8]>>,
+}
+
+impl NVFBCCapture {
+    pub fn new() -> Self {
+        Self {
+            capturer: SystemCapturer::new().expect("Failed to create capturer."),
+            fps: 90,
+            // frame: None,
+        }
+    }
+}
+
+impl WlxCapture for NVFBCCapture {
+    fn init(&mut self, dmabuf_formats: &[DrmFormat]) {
+        let _ = self.capturer.start(BufferFormat::Bgra, self.fps);
+    }
+
+    fn is_ready(&self) -> bool {
+        if let Ok(status) = self.capturer.status() {
+            return status.is_capture_possible;
+        }
+        false
+    }
+
+    fn supports_dmbuf(&self) -> bool {
+        false
+    }
+
+    fn receive(&mut self) -> Option<WlxFrame> {
+        match self.capturer.status() {
+            Ok(status) if !status.is_capture_possible => {
+                return None;
+            }
+            Ok(_status) => {}
+            Err(_) => return None,
+        }
+        if let Ok(frame_info) = self.capturer.next_frame(CaptureMethod::NoWait) {
+            log::trace!("{:#?}", frame_info);
+
+            let memptr = MemPtrFrame {
+                format: FrameFormat {
+                    width: frame_info.width,
+                    height: frame_info.height,
+                    fourcc: DRM_FORMAT_ARGB8888.into(),
+                    ..Default::default()
+                },
+                ptr: frame_info.buffer.as_ptr() as _,
+                size: frame_info.buffer.len(),
+                mouse: None,
+            };
+
+            return Some(WlxFrame::MemPtr(memptr));
+        }
+        None
+    }
+
+    fn pause(&mut self) {
+        self.capturer.stop().expect("Failed to stop capture.");
+    }
+
+    fn resume(&mut self) {
+        let _ = self.capturer.start(BufferFormat::Bgra, self.fps);
+    }
+
+    fn request_new_frame(&mut self) {}
+}

--- a/src/nvfbc.rs
+++ b/src/nvfbc.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc;
+
 use crate::{
     frame::{DrmFormat, FrameFormat, MemPtrFrame, WlxFrame, DRM_FORMAT_ARGB8888},
     WlxCapture,
@@ -5,31 +7,87 @@ use crate::{
 use nvfbc::system::CaptureMethod;
 use nvfbc::{BufferFormat, SystemCapturer};
 pub struct NVFBCCapture {
-    capturer: SystemCapturer,
-    fps: u32,
-    // frame: Option<Box<[u8]>>,
+    sender: Option<mpsc::SyncSender<()>>,
+    receiver: Option<mpsc::Receiver<WlxFrame>>,
 }
 
 impl NVFBCCapture {
     pub fn new() -> Self {
         Self {
-            capturer: SystemCapturer::new().expect("Failed to create capturer."),
-            fps: 90,
+            sender: None,
+            receiver: None,
             // frame: None,
         }
     }
 }
 
 impl WlxCapture for NVFBCCapture {
-    fn init(&mut self, dmabuf_formats: &[DrmFormat]) {
-        let _ = self.capturer.start(BufferFormat::Bgra, self.fps);
+    fn init(&mut self, _: &[DrmFormat]) {
+        let (tx_frame, rx_frame) = std::sync::mpsc::sync_channel(4);
+        let (tx_cmd, rx_cmd) = std::sync::mpsc::sync_channel(2);
+        self.sender = Some(tx_cmd);
+        self.receiver = Some(rx_frame);
+
+        std::thread::spawn({
+            move || {
+                let mut capturer = SystemCapturer::new().expect("Failed to create capturer.");
+                if capturer.start(BufferFormat::Bgra, 90).is_err() {
+                    log::error!("Failed to create NvFBC Capturer");
+                    return;
+                };
+
+                loop {
+                    let monitor_name = "NvFBC Main Monitor"; //capturer.status().unwrap().outputs[0].name;
+                    match rx_cmd.recv() {
+                        Ok(_) => {
+                            if let Ok(frame_info) = capturer.next_frame(CaptureMethod::NoWait) {
+                                log::trace!("{:#?}", frame_info);
+
+                                let memptr_frame = MemPtrFrame {
+                                    format: FrameFormat {
+                                        width: frame_info.width,
+                                        height: frame_info.height,
+                                        fourcc: DRM_FORMAT_ARGB8888.into(),
+                                        ..Default::default()
+                                    },
+                                    ptr: frame_info.buffer.as_ptr() as _,
+                                    size: frame_info.buffer.len(),
+                                    mouse: None,
+                                };
+
+                                log::trace!("{} captured frame: {:#?}", monitor_name, frame_info);
+
+                                let frame = WlxFrame::MemPtr(memptr_frame);
+                                match tx_frame.try_send(frame) {
+                                    Ok(_) => (),
+                                    Err(mpsc::TrySendError::Full(_)) => {
+                                        log::debug!("{}: channel full", monitor_name);
+                                    }
+                                    Err(mpsc::TrySendError::Disconnected(_)) => {
+                                        log::warn!(
+                                            "{}: capture thread channel closed (send)",
+                                            monitor_name,
+                                        );
+                                        break;
+                                    }
+                                }
+                            } else {
+                                log::debug!("{}: NvFBC capture failed failed", monitor_name);
+                            }
+                        }
+                        Err(_) => {
+                            log::warn!("{}: capture thread channel closed (recv)", monitor_name);
+                            break;
+                        }
+                    }
+                }
+                log::warn!("NvFBC capture thread stopped");
+            }
+        });
     }
 
     fn is_ready(&self) -> bool {
-        if let Ok(status) = self.capturer.status() {
-            return status.is_capture_possible;
-        }
-        false
+        self.receiver.is_some()
     }
 
     fn supports_dmbuf(&self) -> bool {
@@ -37,40 +95,24 @@ impl WlxCapture for NVFBCCapture {
     }
 
     fn receive(&mut self) -> Option<WlxFrame> {
-        match self.capturer.status() {
-            Ok(status) if !status.is_capture_possible => {
-                return None;
-            }
-            Ok(_status) => {}
-            Err(_) => return None,
-        }
-        if let Ok(frame_info) = self.capturer.next_frame(CaptureMethod::NoWait) {
-            log::trace!("{:#?}", frame_info);
-
-            let memptr = MemPtrFrame {
-                format: FrameFormat {
-                    width: frame_info.width,
-                    height: frame_info.height,
-                    fourcc: DRM_FORMAT_ARGB8888.into(),
-                    ..Default::default()
-                },
-                ptr: frame_info.buffer.as_ptr() as _,
-                size: frame_info.buffer.len(),
-                mouse: None,
-            };
-
-            return Some(WlxFrame::MemPtr(memptr));
+        if let Some(rx) = self.receiver.as_ref() {
+            return rx.try_iter().last();
         }
         None
     }
 
-    fn pause(&mut self) {
-        self.capturer.stop().expect("Failed to stop capture.");
-    }
+    fn pause(&mut self) {}
 
     fn resume(&mut self) {
-        let _ = self.capturer.start(BufferFormat::Bgra, self.fps);
+        self.receive(); // clear old frames
+        self.request_new_frame();
     }
 
-    fn request_new_frame(&mut self) {}
+    fn request_new_frame(&mut self) {
+        if let Some(sender) = &self.sender {
+            if let Err(e) = sender.send(()) {
+                log::debug!("Failed to send frame request: {}", e);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This adds Nvidia Framebuffer Capture support on X11 using [this wrapper](https://github.com/hgaiser/nvfbc-rs/tree/main/nvfbc). 

This PR still copies to the framebuffer to system memory, but it's still noticeably a lot faster than Xshm, but NvFBC does support copying into a OpenGL texture, but copying to system memory first seems fast enough in wlx-overlay-s.

The other issue is that this NvFBC wrapper package doesn't _seem_ to support capturing from other monitors besides the first one, but I think I must be doing something wrong. I haven't tested this with multiple monitors.

The capture frame rate is also currently hardcoded and it should probably match the monitor refresh rate or the headset refresh rate, which ever is lower. 

Meant to be used with https://github.com/galister/wlx-overlay-s/pull/173

